### PR TITLE
Update find-visualstudio.js

### DIFF
--- a/lib/find-visualstudio.js
+++ b/lib/find-visualstudio.js
@@ -129,6 +129,8 @@ VisualStudioFinder.prototype = {
       'WindowsPowerShell', 'v1.0', 'powershell.exe')
     var csFile = path.join(__dirname, 'Find-VisualStudio.cs')
     var psArgs = [
+      '-Version',
+      '2',
       '-ExecutionPolicy',
       'Unrestricted',
       '-NoProfile',


### PR DESCRIPTION
'Add-Type' cannot be used in powershell with constrained language mode. Language mode does not exist in PowerShell 2.0 engine. To force powershell to use 2.0 engine allows the usage of msvc 2017 or newer in environment with constrained language mode.
See : 
https://devblogs.microsoft.com/powershell/powershell-constrained-language-mode/
https://docs.microsoft.com/en-us/powershell/scripting/windows-powershell/starting-the-windows-powershell-2.0-engine?view=powershell-7.1

<!--
Thank you for your pull request. Please review the below requirements.

Contributor guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm install && npm test` passes
- [ ] tests are included <!-- Bug fixes and new features should include tests -->
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/googleapis/release-please#how-should-i-write-my-commits)

##### Description of change
<!-- Provide a description of the change -->

